### PR TITLE
Strip image ID to fix metrics on dockershim

### DIFF
--- a/internal/vuln/kubernetes/kubernetes.go
+++ b/internal/vuln/kubernetes/kubernetes.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -71,7 +72,8 @@ func (client *KubeClient) GetContainersWithImage(imageID string) ([]ContainerInf
 		statuses = append(statuses, p.Status.EphemeralContainerStatuses...)
 
 		for _, c := range statuses {
-			if c.ImageID == imageID {
+			fixedImageID := strings.ReplaceAll(c.ImageID, "docker-pullable://", "")
+			if fixedImageID == imageID {
 				infos = append(infos, ContainerInfo{
 					Namespace:     p.Namespace,
 					PodName:       p.Name,


### PR DESCRIPTION
This addresses #175 and removes the prefix `docker-pullable://` from image IDs.