### PR TITLE
fix: Fixed bug in match function

### DIFF
--- a/internal/vuln/filter/filter.go
+++ b/internal/vuln/filter/filter.go
@@ -47,41 +47,37 @@ func matches(v vuln.Vulnerability, filter VulnerabilityFilter) (bool, vuln.Vulne
 	appliedContainers := make([]kubernetes.ContainerInfo, 0)
 	notAppliedContainers := make([]kubernetes.ContainerInfo, 0)
 
-	if len(filter.Context) > 0 {
-		for _, ctx := range filter.Context {
-			for _, container := range v.Containers {
-				name := container.OwnerName
-				if container.OwnerKind == "Pod" {
-					name = container.PodName
-				}
+	if v.ID != filter.Vulnerability && v.Package != filter.Package {
+		notAppliedContainers = v.Containers
+		return false, fromVulnerability(v, appliedContainers), fromVulnerability(v, notAppliedContainers)
+	} else if len(filter.Context) == 0 {
+		appliedContainers = v.Containers
+		return true, fromVulnerability(v, appliedContainers), fromVulnerability(v, notAppliedContainers)
+	}
 
-				if matchesContainer(v.ImageID, ctx.Image) &&
-					matchesContainer(container.OwnerKind, ctx.Kind) &&
-					matchesContainer(name, ctx.Name) &&
-					matchesContainer(container.Namespace, ctx.Namespace) {
-					appliedContainers = append(appliedContainers, container)
-				} else {
-					notAppliedContainers = append(notAppliedContainers, container)
-				}
+	for _, container := range v.Containers {
+		name := container.OwnerName
+		if container.OwnerKind == "Pod" {
+			name = container.PodName
+		}
+
+		applied := false
+		for _, ctx := range filter.Context {
+			if matchesContainer(v.ImageID, ctx.Image) &&
+				matchesContainer(container.OwnerKind, ctx.Kind) &&
+				matchesContainer(name, ctx.Name) &&
+				matchesContainer(container.Namespace, ctx.Namespace) {
+				appliedContainers = append(appliedContainers, container)
+				applied = true
+				break
 			}
 		}
-	} else {
-		appliedContainers = v.Containers
+		if !applied {
+			notAppliedContainers = append(notAppliedContainers, container)
+		}
 	}
 
-	if len(appliedContainers) == 0 {
-		return false, fromVulnerability(v, appliedContainers), fromVulnerability(v, notAppliedContainers)
-	}
-
-	if v.ID == filter.Vulnerability {
-		return true, fromVulnerability(v, appliedContainers), fromVulnerability(v, notAppliedContainers)
-	}
-
-	if v.Package == filter.Package {
-		return true, fromVulnerability(v, appliedContainers), fromVulnerability(v, notAppliedContainers)
-	}
-
-	return false, fromVulnerability(v, appliedContainers), fromVulnerability(v, notAppliedContainers)
+	return len(appliedContainers) != 0, fromVulnerability(v, appliedContainers), fromVulnerability(v, notAppliedContainers)
 }
 
 func matchesContainer(value, pattern string) bool {


### PR DESCRIPTION
Fixed bug which caused non-matched filter contexts to cause container to be be added to the unmatched containers even if another context was a match.

I was getting such issues by following #420 

Please give feedback. I believe this a corrected version. It is also much much faster. I believe `matchesAnyFilter` is also not quite right, because you could have multiple filters that match a container. I think I could fix both of these by creating a hash table which is keyed by either `package` or `vulnerability`. That way, you know exactly which filters you should look at. No iteration, and no ambiguity when it comes to multiple overlapping filters. Thoughts on PR as is, as well as my idea to changes?