### PR TITLE
Fix filtering algorithm #444

### DIFF
--- a/internal/vuln/filter/filter.go
+++ b/internal/vuln/filter/filter.go
@@ -32,56 +32,87 @@ func (f *FilterEngine) FilterVulnerabilities(vulns []vuln.Vulnerability) ([]vuln
 	return found, audited
 }
 
-func matchesAnyFilter(v vuln.Vulnerability, filters []VulnerabilityFilter) (vuln.Vulnerability, vuln.Vulnerability) {
+func createConcatFilter(v vuln.Vulnerability, filters []VulnerabilityFilter) VulnerabilityFilter {
+	concatFilter := VulnerabilityFilter{
+		Vulnerability: "",
+		Package:       "",
+		Context:       make([]FilterContext, 0),
+	}
+
+	atLeastOneFilter := false
+
 	for _, filter := range filters {
-		match, filtered, notFiltered := matches(v, filter)
-		if match {
-			return filtered, notFiltered
+		if filter.Vulnerability == v.ID || filter.Package == v.Package {
+			atLeastOneFilter = true
+
+			// This is an edge case where we have at least one filter with an empty context.
+			// It should supercede any more specific filter
+			if len(filter.Context) == 0 {
+				concatFilter.Context = make([]FilterContext, 0)
+				break
+			}
+			concatFilter.Context = append(concatFilter.Context, filter.Context...)
 		}
 	}
 
-	return vuln.Vulnerability{}, v
+	if atLeastOneFilter {
+		concatFilter.Vulnerability = v.ID
+		concatFilter.Package = v.Package
+	}
+
+	return concatFilter
 }
 
-func matches(v vuln.Vulnerability, filter VulnerabilityFilter) (bool, vuln.Vulnerability, vuln.Vulnerability) {
+func matchesAnyFilter(v vuln.Vulnerability, filters []VulnerabilityFilter) (vuln.Vulnerability, vuln.Vulnerability) {
+	concatFilter := createConcatFilter(v, filters)
+	_, filtered, notFiltered := matches(v, concatFilter)
+	return filtered, notFiltered
+}
+
+func matches(v vuln.Vulnerability, filter VulnerabilityFilter) (matched bool, appliedVuln vuln.Vulnerability, notAppliedVuln vuln.Vulnerability) {
 	appliedContainers := make([]kubernetes.ContainerInfo, 0)
 	notAppliedContainers := make([]kubernetes.ContainerInfo, 0)
 
-	if len(filter.Context) > 0 {
-		for _, ctx := range filter.Context {
-			for _, container := range v.Containers {
-				name := container.OwnerName
-				if container.OwnerKind == "Pod" {
-					name = container.PodName
-				}
+	defer func() {
+		matched = len(appliedContainers) > 0
+		appliedVuln = fromVulnerability(v, appliedContainers)
+		notAppliedVuln = fromVulnerability(v, notAppliedContainers)
+	}()
 
+	// We can just shortcut and return false if this filter does not match.
+	if v.ID != filter.Vulnerability && v.Package != filter.Package {
+		notAppliedContainers = v.Containers
+		return
+	}
+
+	if len(filter.Context) > 0 {
+		for _, container := range v.Containers {
+			name := container.OwnerName
+			if container.OwnerKind == "Pod" {
+				name = container.PodName
+			}
+
+			// if any context matches the container, then the filter matches the container
+			applied := false
+			for _, ctx := range filter.Context {
 				if matchesContainer(v.ImageID, ctx.Image) &&
 					matchesContainer(container.OwnerKind, ctx.Kind) &&
 					matchesContainer(name, ctx.Name) &&
 					matchesContainer(container.Namespace, ctx.Namespace) {
 					appliedContainers = append(appliedContainers, container)
-				} else {
-					notAppliedContainers = append(notAppliedContainers, container)
+					applied = true
+					break
 				}
+			}
+			if !applied {
+				notAppliedContainers = append(notAppliedContainers, container)
 			}
 		}
 	} else {
 		appliedContainers = v.Containers
 	}
 
-	if len(appliedContainers) == 0 {
-		return false, fromVulnerability(v, appliedContainers), fromVulnerability(v, notAppliedContainers)
-	}
-
-	if v.ID == filter.Vulnerability {
-		return true, fromVulnerability(v, appliedContainers), fromVulnerability(v, notAppliedContainers)
-	}
-
-	if v.Package == filter.Package {
-		return true, fromVulnerability(v, appliedContainers), fromVulnerability(v, notAppliedContainers)
-	}
-
-	return false, fromVulnerability(v, appliedContainers), fromVulnerability(v, notAppliedContainers)
+	return
 }
 
 func matchesContainer(value, pattern string) bool {

--- a/internal/vuln/filter/filter_test.go
+++ b/internal/vuln/filter/filter_test.go
@@ -328,6 +328,12 @@ func TestFilterVulnerabilities(t *testing.T) {
 			audited:  []vuln.Vulnerability{{ID: "CVE-2023-0215", Package: "libcrypto3", Severity: "High", Type: "apk", ImageID: "alpine:3.17", Containers: []kubernetes.ContainerInfo{{Namespace: "monitoring", OwnerName: "grafana", OwnerKind: "Deployment", PodName: "grafana-6d54bf9447-t7dfc"}, {Namespace: "monitoring", OwnerName: "kube-state-metrics", OwnerKind: "Deployment", PodName: "kube-state-metrics-6d54bf9447-t7dfc"}}}},
 			found:    []vuln.Vulnerability{},
 		},
+		{
+			config:   FilterConfig{Audit: []VulnerabilityFilter{{Vulnerability: "CVE-2023-0215", Context: []FilterContext{{Namespace: "monitoring", Kind: "Deployment", Name: "grafana"}}}, {Vulnerability: "CVE-2023-0215", Context: []FilterContext{}}}},
+			vulnList: []vuln.Vulnerability{libcryptoVulnMultiDeployment},
+			audited:  []vuln.Vulnerability{{ID: "CVE-2023-0215", Package: "libcrypto3", Severity: "High", Type: "apk", ImageID: "alpine:3.17", Containers: []kubernetes.ContainerInfo{{Namespace: "monitoring", OwnerName: "grafana", OwnerKind: "Deployment", PodName: "grafana-6d54bf9447-t7dfc"}, {Namespace: "monitoring", OwnerName: "kube-state-metrics", OwnerKind: "Deployment", PodName: "kube-state-metrics-6d54bf9447-t7dfc"}}}},
+			found:    []vuln.Vulnerability{},
+		},
 	}
 
 	for _, v := range tests {

--- a/internal/vuln/filter/filter_test.go
+++ b/internal/vuln/filter/filter_test.go
@@ -316,6 +316,18 @@ func TestFilterVulnerabilities(t *testing.T) {
 			audited:  []vuln.Vulnerability{{ID: "CVE-2023-0215", Package: "libcrypto3", Severity: "High", Type: "apk", ImageID: "alpine:3.17", Containers: []kubernetes.ContainerInfo{{Namespace: "monitoring", OwnerName: "grafana", OwnerKind: "Deployment", PodName: "grafana-6d54bf9447-t7dfc"}}}},
 			found:    []vuln.Vulnerability{},
 		},
+		{
+			config:   FilterConfig{Audit: []VulnerabilityFilter{{Vulnerability: "CVE-2023-0215", Context: []FilterContext{{Namespace: "monitoring", Kind: "Deployment", Name: "grafana"}, {Namespace: "monitoring", Kind: "Deployment", Name: "kube-state-metrics"}}}}},
+			vulnList: []vuln.Vulnerability{libcryptoVulnMultiDeployment},
+			audited:  []vuln.Vulnerability{{ID: "CVE-2023-0215", Package: "libcrypto3", Severity: "High", Type: "apk", ImageID: "alpine:3.17", Containers: []kubernetes.ContainerInfo{{Namespace: "monitoring", OwnerName: "grafana", OwnerKind: "Deployment", PodName: "grafana-6d54bf9447-t7dfc"}, {Namespace: "monitoring", OwnerName: "kube-state-metrics", OwnerKind: "Deployment", PodName: "kube-state-metrics-6d54bf9447-t7dfc"}}}},
+			found:    []vuln.Vulnerability{},
+		},
+		{
+			config:   FilterConfig{Audit: []VulnerabilityFilter{{Vulnerability: "CVE-2023-0215", Context: []FilterContext{{Namespace: "monitoring", Kind: "Deployment", Name: "grafana"}}}, {Vulnerability: "CVE-2023-0215", Context: []FilterContext{{Namespace: "monitoring", Kind: "Deployment", Name: "kube-state-metrics"}}}}},
+			vulnList: []vuln.Vulnerability{libcryptoVulnMultiDeployment},
+			audited:  []vuln.Vulnerability{{ID: "CVE-2023-0215", Package: "libcrypto3", Severity: "High", Type: "apk", ImageID: "alpine:3.17", Containers: []kubernetes.ContainerInfo{{Namespace: "monitoring", OwnerName: "grafana", OwnerKind: "Deployment", PodName: "grafana-6d54bf9447-t7dfc"}, {Namespace: "monitoring", OwnerName: "kube-state-metrics", OwnerKind: "Deployment", PodName: "kube-state-metrics-6d54bf9447-t7dfc"}}}},
+			found:    []vuln.Vulnerability{},
+		},
 	}
 
 	for _, v := range tests {


### PR DESCRIPTION
This PR fixes the issues described in #444. The bugs fixed are demonstrated by the three tests that I added (the current release fails all three). This PR supersedes #431 and #432, so I have closed those. As a bonus, this version of the filtering is MUCH faster than the current release. In the current release, one of my clusters was taking an hour or two for one complete scan (filter file on the order of a few MB in size), whereas this version takes a couple minutes.

Some things of note:

- The logic of the existing release code implies that a filter rule is allowed to have both a `package` and `vulnerability`, and the found vulnerability is a match if at least one of these properties matches it. This is demonstrated here: https://github.com/ckotzbauer/vulnerability-operator/blob/5e293175d9afc0461a068277f86587512390eb26/internal/vuln/filter/filter.go#L76

This is of course equivalent to:
```go
	if v.ID == filter.Vulnerability || v.Package == filter.Package {
		return true, fromVulnerability(v, appliedContainers), fromVulnerability(v, notAppliedContainers)
	}
```

I wasn't sure if this was intended, but I kept this functionality in my fix (my assumption was that it wasn't considered that `package` and `vulnerability` properties could potentially be used together).

- The first two test cases demonstrate explicitly the issues described in #444. The third test case covers the case where you have a filter file like this:
```
audit:
- vulnerability: CVE-1
  context:
  - image: image1
    namespace: namespace1
- vulnerability: CVE-1
```
According to the logic of the documentation and the existing release code, the first filter rule should essentially be a no-op because the second rule has an empty context and therefore should match all instances CVE-1, as demonstrated by the existing release code here: https://github.com/ckotzbauer/vulnerability-operator/blob/5e293175d9afc0461a068277f86587512390eb26/internal/vuln/filter/filter.go#L69

I think this particular example is really an edge case because I don't think you would write a filter file like this.

Nevertheless, here is the test case I wrote to cover this edge case: https://github.com/samcornwell/vulnerability-operator/commit/a922d36b1ae1520c5964d8d02c0f220cf5576d63, reformatted here for easier reading:

```go
{
    config: FilterConfig{
        Audit: []VulnerabilityFilter{
            {
                Vulnerability: "CVE-2023-0215", 
                Context: []FilterContext{
                    {
                        Namespace: "monitoring", 
                        Kind: "Deployment", 
                        Name: "grafana"
                    }
                }
            }, 
            {
                Vulnerability: "CVE-2023-0215", 
                Context: []FilterContext{}
            }
        }
    },
    vulnList: []vuln.Vulnerability{
        libcryptoVulnMultiDeployment
    },
    audited: []vuln.Vulnerability{
        {
            ID: "CVE-2023-0215", 
            Package: "libcrypto3", 
            Severity: "High", 
            Type: "apk", 
            ImageID: "alpine:3.17", 
            Containers: []kubernetes.ContainerInfo{
                {
                    Namespace: "monitoring", 
                    OwnerName: "grafana", 
                    OwnerKind: "Deployment", 
                    PodName: "grafana-6d54bf9447-t7dfc"
                }, 
                {
                    Namespace: "monitoring", 
                    OwnerName: "kube-state-metrics", 
                    OwnerKind: "Deployment", 
                    PodName: "kube-state-metrics-6d54bf9447-t7dfc"
                }
            }
        }
    },
    found: []vuln.Vulnerability{}
}
```

